### PR TITLE
Fix 4 Xcode implicit conversion warnings

### DIFF
--- a/MagicKit.xcodeproj/project.pbxproj
+++ b/MagicKit.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 0510;
 			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "MagicKit" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -575,7 +575,6 @@
 		1DEB91B208733DA50010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -589,7 +588,6 @@
 		1DEB91B308733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -641,7 +639,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = armv7;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -656,7 +653,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = armv7;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "HAVE_CONFIG_H=1";

--- a/libmagic/apprentice.c
+++ b/libmagic/apprentice.c
@@ -1935,7 +1935,7 @@ getvalue(struct magic_set *ms, struct magic *m, const char **p, int action)
  * Copy the converted version to "m->value.s", and the length in m->vallen.
  * Return updated scan pointer as function result. Warn if set.
  */
-private const char *
+__attribute__((overloadable)) private const char *
 getstr(struct magic_set *ms, struct magic *m, const char *s, int warn)
 {
 	const char *origs = s;

--- a/libmagic/file.c
+++ b/libmagic/file.c
@@ -126,7 +126,7 @@ private void help(void);
 int main(int, char *[]);
 
 private int unwrap(struct magic_set *, const char *);
-private int process(struct magic_set *ms, const char *, int);
+private int process(struct magic_set *ms, const char *, size_t);
 private struct magic_set *load(const char *, int);
 
 
@@ -372,7 +372,7 @@ unwrap(struct magic_set *ms, const char *fn)
 	ssize_t len;
 	char *line = NULL;
 	size_t llen = 0;
-	int wid = 0, cwid;
+	size_t wid = 0, cwid;
 	int e = 0;
 
 	if (strcmp("-", fn) == 0) {
@@ -413,7 +413,7 @@ unwrap(struct magic_set *ms, const char *fn)
  * Called for each input file on the command line (or in a list of files)
  */
 private int
-process(struct magic_set *ms, const char *inname, int wid)
+process(struct magic_set *ms, const char *inname, size_t wid)
 {
 	const char *type;
 	int std_in = strcmp(inname, "-") == 0;

--- a/libmagic/vasprintf.c
+++ b/libmagic/vasprintf.c
@@ -521,7 +521,7 @@ static int dispatch(xprintf_struct *s)
       int * p;
       p = va_arg(s->vargs, int *);
       if (p != NULL) {
-        *p = s->pseudo_len;
+        *p = (int)s->pseudo_len;
         return 0;
       }
       return EOF;
@@ -605,7 +605,7 @@ static int core(xprintf_struct *s)
   s->buffer_base = (char *)realloc((void *)(s->buffer_base), save_len + 1);
   if (s->buffer_base == NULL)
     return EOF; /* should rarely happen because we shrink the buffer */
-  return s->pseudo_len;
+  return (int)s->pseudo_len;
 
  free_EOF:
   free(s->buffer_base);


### PR DESCRIPTION
Hello,

It would be nice to have MagicKit 0.0.2 release which could be compiled with no warnings. 

Thanks.
